### PR TITLE
Fix reading metadata

### DIFF
--- a/Content.php
+++ b/Content.php
@@ -107,7 +107,7 @@ class Content {
      * current message comment section.
      */
     private function extractMetadata(): void {
-        if (preg_match('#(?P<metadata>\s{3}submitted.*</span>)#', $this->raw, $matches)) {
+        if (preg_match('#(?P<metadata>\s*?submitted.*</span>)#', $this->raw, $matches)) {
             $this->metadata = $matches['metadata'];
         }
     }


### PR DESCRIPTION
Noticed that nsfw posts have a bit of a different formatting to it.
For example:
> content type="html">&amp;#32; submitted by &amp;#32; 

Noticed that #14 was made and this change also fixes that, so this formatting is not actually limited to nsfw posts.

Don't think it needs to specify the number of expected whitespaces.
This change works for both images and videos, `r/PublicFreakout` is pretty easy to test for the video side. Know that these videos do not provide a thumbnail image, but I don't think that's a big deal either.
